### PR TITLE
v3.8.1 (#157)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.8.1] - 2021-04-01
+
+### Fixed
+- Adjusted JS for mode custom checkout using gateway mode
+- Refined load installments on change issuer
+- Removed from log access token information
+
 ## [3.8.0] - 2021-03-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   </a>
 </p>
 
-# Magento 2 - Mercado Pago Module (v3.8.0)
+# Magento 2 - Mercado Pago Module (v3.8.1)
 
 The Mercado Pago plugin for Magento 2 allows you to expand the functionalities of your online store and offer a unique payment experience for your customers.
 

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     }
   ],
   "type": "magento2-component",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "license": [
     "OSL-3.0",
     "AFL-3.0"

--- a/src/MercadoPago/Core/Observer/ConfigObserver.php
+++ b/src/MercadoPago/Core/Observer/ConfigObserver.php
@@ -230,8 +230,6 @@ class ConfigObserver
             $this->_scopeCode
         );
 
-        $this->coreHelper->log("Get access_token: " . $accessToken, self::LOG_NAME);
-
         if (!$accessToken) {
             return;
         }

--- a/src/MercadoPago/Core/composer.json
+++ b/src/MercadoPago/Core/composer.json
@@ -2,7 +2,7 @@
     "name": "mercadopago/core",
     "description": "Mercado Pago payment method module",
     "type": "magento2-module",
-    "version": "3.8.0",
+    "version": "3.8.1",
     "license": [
         "OSL-3.0",
         "AFL-3.0"

--- a/src/MercadoPago/Core/etc/module.xml
+++ b/src/MercadoPago/Core/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="MercadoPago_Core" setup_version="3.8.0">
+    <module name="MercadoPago_Core" setup_version="3.8.1">
         <sequence>
             <module name="Magento_Sales"/>
             <module name="Magento_Payment"/>

--- a/src/MercadoPago/Core/view/frontend/requirejs-config.js
+++ b/src/MercadoPago/Core/view/frontend/requirejs-config.js
@@ -5,7 +5,7 @@
 let config = {
     map: {
         '*': {
-            MPcustom: 'https://secure.mlstatic.com/sdk/javascript/v1/mercadopago.js?_magento=3.8.0',
+            MPcustom: 'https://secure.mlstatic.com/sdk/javascript/v1/mercadopago.js?_magento=3.8.1',
             MPv1: 'MercadoPago_Core/js/MPv1',
             MPv1Ticket: 'MercadoPago_Core/js/MPv1Ticket'
         }

--- a/src/MercadoPago/Core/view/frontend/web/css/MPv1.css
+++ b/src/MercadoPago/Core/view/frontend/web/css/MPv1.css
@@ -324,7 +324,6 @@
   display: none;
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   clear: both;
-  float: left;
   width: 100%;
 }
 

--- a/src/MercadoPago/Core/view/frontend/web/js/MPv1.js
+++ b/src/MercadoPago/Core/view/frontend/web/js/MPv1.js
@@ -143,11 +143,12 @@
             MPv1.hideIssuer();
 
             var selectorInstallments = document.querySelector(MPv1.selectors.installments),
-                fragment = document.createDocumentFragment(),
-                option = new Option(MPv1.text.choose + "...", '-1');
-
+            option = new Option(MPv1.text.choose + "...", '-1');
             selectorInstallments.options.length = 0;
+
+            fragment = document.createDocumentFragment(),
             fragment.appendChild(option);
+
             selectorInstallments.appendChild(fragment);
             selectorInstallments.setAttribute('disabled', 'disabled');
         }
@@ -200,12 +201,8 @@
                 }
             }
 
-            if (issuerMandatory) {
-                var payment_method_id = response[0].id;
-                MPv1.getIssuersPaymentMethod(payment_method_id);
-            } else {
-                MPv1.hideIssuer();
-            }
+            var payment_method_id = response[0].id;
+            MPv1.getIssuersPaymentMethod(payment_method_id);
         }
     }
 
@@ -258,11 +255,11 @@
             }
             /** END Gateway Mode **/
 
-            var issuersSelector = document.querySelector(MPv1.selectors.issuer),
-                fragment = document.createDocumentFragment();
-
+            var issuersSelector = document.querySelector(MPv1.selectors.issuer);
             issuersSelector.options.length = 0;
             var option = new Option(MPv1.text.choose + "...", '-1');
+
+            fragment = document.createDocumentFragment();
             fragment.appendChild(option);
 
             for (var i = 0; i < issuers.length; i++) {
@@ -273,9 +270,14 @@
                 }
                 fragment.appendChild(option);
             }
+
             issuersSelector.appendChild(fragment);
             issuersSelector.removeAttribute('disabled');
-            //document.querySelector(MPv1.selectors.issuer).removeAttribute('style');
+
+            if (issuersSelector.options.length <= 1) {
+                MPv1.hideIssuer();
+            }
+
         } else {
             MPv1.hideIssuer();
         }
@@ -334,7 +336,7 @@
                     var installments = response[x];
                     if (installments.processing_mode == 'gateway') {
                         payerCosts = installments.payer_costs
-                        document.querySelector(MPv1.selectors.gateway_mode).value = installments.merchant_account_id;
+                        document.querySelector(MPv1.selectors.MpGatewayMode).value = installments.merchant_account_id;
                     }
                 }
             }

--- a/src/MercadoPago/Core/view/frontend/web/js/view/method-renderer/custom-method.js
+++ b/src/MercadoPago/Core/view/frontend/web/js/view/method-renderer/custom-method.js
@@ -54,21 +54,20 @@ define(
             payer_email = quote.guestEmail
           }
 
-          MPv1.text.choose = $t('Choose');
-          MPv1.text.other_bank = $t('Other Bank');
-          MPv1.gateway_mode = window.checkoutConfig.payment[this.getCode()]['gateway_mode'];
-
-          //add actions 
+          //add actions
           self.initializeInstallmentsAndIssuer();
-
-          //change url loading
-          MPv1.paths.loading = window.checkoutConfig.payment[this.getCode()]['loading_gif'];
-          MPv1.customer_and_card.default = false;
 
           //Initialize MPv1
           MPv1.Initialize(mercadopago_site_id, mercadopago_public_key, payer_email);
 
-      
+          //change url loading for MPv1
+          MPv1.paths.loading = window.checkoutConfig.payment[this.getCode()]['loading_gif'];
+          MPv1.customer_and_card.default = false;
+
+          // update MPv1 params
+          MPv1.text.choose = $t('Choose');
+          MPv1.text.other_bank = $t('Other Bank');
+          MPv1.gateway_mode = window.checkoutConfig.payment[this.getCode()]['mp_gateway_mode'];
 
           //get action change payment method
           quote.paymentMethod.subscribe(self.changePaymentMethodSelector, null, 'change');


### PR DESCRIPTION
* removing mp analytics support

* Rename checkout basic to checkout pro

* set less additional info

* create skeleton of pix checkout

* pix gateway skeleton

* Add new gateway parameters on admin

* Add new GW on orderCancelPlugin

* Check if pix has avalaible and notify when user no has pix key

* add pix information and close order with pix

* show/hide pix gateway by country

* adjusted custom pix payment

* adjusted custom pix payment

* refinement gateway and change icons

* refinement gateway pix color

* Template success pix

* Template success magento

* Fix template success magento

* Fix template success magento

* pix expiration date

* template finished

* add try catch on call api without access token

* adjusted word on i18n

* Translate pix congrats

* Removed coupon dicount of JS, HTML, provider and controler

* adjusted phrase for expiration days description

* Removed Coupon from admin ticket and Cards and backend

* add getbin on issuer call

* When the pix is not avalaible.. disable it

* Changes to be committed:
	modified:   composer.json
	modified:   src/MercadoPago/Core/Plugin/OrderCancelPlugin.php

* Set BRL format to display amount on success page

* Clean config cache after display notification

* Updated checkouts sort order

* Fixed translation

* Updated metadata

* fixed custom error messages and adjusted pix translate

* fixed ko tag

* fixed ko tag

* fixed case of v

* prepare new release 3.8.0

* Hotfix gateway mode on MPv1.js

* Hotfix gateway mode on MPv1.js

* Removing access token from log

* Hotfix gateway mode on MPv1.js

* New release 3.8.1 same fixes

Co-authored-by: katelucena <kate.lucena@mercadolivre.com>
Co-authored-by: Fabio Landi <fabio.landi@mercadolivre.com>
Co-authored-by: Luiz Tucillo <luiz.tucillo@mercadolivre.com>
Co-authored-by: Giovanni Cavallari <giovanni.cavallari@mercadolivre.com>
Co-authored-by: Giovanni Cavallari <jobacavallari@hotmail.com>
Co-authored-by: Daniel Lopes Ferreira <daniel.lopes.ferreira98@gmail.com>