### PR TITLE
Setup CI - PHPMD

### DIFF
--- a/.github/workflows/phpcs.yaml
+++ b/.github/workflows/phpcs.yaml
@@ -29,6 +29,7 @@ jobs:
           php-version: "7.3"
           extensions: curl, dom, intl, json, openssl
           coverage: xdebug
+          tools: phpmd
 
       - name: Verify PHP Installation
         run: php -v
@@ -59,6 +60,9 @@ jobs:
       - name: Install MP Plugin
         id: install-plugin
         run: mv src/* magento2/app/code
+
+      - name: Run PHPMD
+        run: phpmd magento2/app/code/MercadoPago/ --ignore-violations-on-exit ansi codesize,unusedcode,naming,cleancode
 
       - name: Config Warnings Exit
         run: magento2/vendor/bin/phpcs --config-set ignore_warnings_on_exit 1


### PR DESCRIPTION
### Add PHPMD Workflow
- if the output has the severity "error", the CI will failure
- if the output has the severity "violation", the CI will not fail, but warnings will be displayed in the output.

PHPMD output example:
![image](https://user-images.githubusercontent.com/84409541/136847908-2ae3bc5e-83f2-49e2-958f-980c6079818f.png)
