### PR TITLE
fix(wallet button): 🐛 create order even with cho pro disabled

### DIFF
--- a/src/MercadoPago/Core/Model/Basic/Payment.php
+++ b/src/MercadoPago/Core/Model/Basic/Payment.php
@@ -24,60 +24,83 @@ use MercadoPago\Core\Model\Preference\Basic;
 
 /**
  * Class Payment
+ *
  * @package MercadoPago\Core\Model\Basic
  */
 class Payment extends AbstractMethod
 {
-    const CODE = 'mercadopago_basic';
+    const CODE       = 'mercadopago_basic';
     const ACTION_URL = 'mercadopago/basic/pay';
 
     /**
      *  Self fields
      */
     protected $_scopeConfig;
+
     protected $_helperData;
+
     protected $_helperImage;
+
     protected $_checkoutSession;
+
     protected $_customerSession;
+
     protected $_orderFactory;
+
     protected $_urlBuilder;
+
     protected $_basic;
 
     /**
      *  Overrides fields
      */
     protected $_code = self::CODE;
+
     protected $_isGateway = true;
+
     protected $_canOrder = true;
+
     protected $_canAuthorize = true;
+
     protected $_canCapture = true;
+
     protected $_canCapturePartial = true;
+
     protected $_canRefund = true;
+
     protected $_canRefundInvoicePartial = true;
+
     protected $_canVoid = true;
+
     protected $_canUseInternal = false;
+
     protected $_canFetchTransactionInfo = true;
+
     protected $_canReviewPayment = true;
+
     protected $_infoBlockType = 'MercadoPago\Core\Block\Info';
+
     protected $_isInitializeNeeded = true;
+
 
     /**
      * Payment constructor.
-     * @param dataHelper $helperData
-     * @param Image $helperImage
-     * @param Session $checkoutSession
-     * @param customerSession $customerSession
-     * @param OrderFactory $orderFactory
-     * @param UrlInterface $urlBuilder
-     * @param Context $context
-     * @param Registry $registry
+     *
+     * @param dataHelper                 $helperData
+     * @param Image                      $helperImage
+     * @param Session                    $checkoutSession
+     * @param customerSession            $customerSession
+     * @param OrderFactory               $orderFactory
+     * @param UrlInterface               $urlBuilder
+     * @param Context                    $context
+     * @param Registry                   $registry
      * @param ExtensionAttributesFactory $extensionFactory
-     * @param AttributeValueFactory $customAttributeFactory
-     * @param Data $paymentData
-     * @param ScopeConfigInterface $scopeConfig
-     * @param Logger $logger
-     * @param Basic $basic
-     * @param array $data
+     * @param AttributeValueFactory      $customAttributeFactory
+     * @param Data                       $paymentData
+     * @param ScopeConfigInterface       $scopeConfig
+     * @param Logger                     $logger
+     * @param Basic                      $basic
+     * @param array                      $data
      */
     public function __construct(
         dataHelper $helperData,
@@ -94,7 +117,7 @@ class Payment extends AbstractMethod
         ScopeConfigInterface $scopeConfig,
         Logger $logger,
         Basic $basic,
-        array $data = []
+        array $data=[]
     ) {
         parent::__construct(
             $context,
@@ -109,15 +132,17 @@ class Payment extends AbstractMethod
             $data
         );
 
-        $this->_helperData = $helperData;
-        $this->_helperImage = $helperImage;
+        $this->_helperData      = $helperData;
+        $this->_helperImage     = $helperImage;
         $this->_checkoutSession = $checkoutSession;
         $this->_customerSession = $customerSession;
-        $this->_orderFactory = $orderFactory;
-        $this->_urlBuilder = $urlBuilder;
-        $this->_scopeConfig = $scopeConfig;
-        $this->_basic = $basic;
-    }
+        $this->_orderFactory    = $orderFactory;
+        $this->_urlBuilder      = $urlBuilder;
+        $this->_scopeConfig     = $scopeConfig;
+        $this->_basic           = $basic;
+
+    }//end __construct()
+
 
     /**
      * @return array
@@ -134,47 +159,53 @@ class Payment extends AbstractMethod
                 $init_point = $payment['init_point'];
 
                 $array_assign = [
-                    "init_point" => $init_point,
-                    "status" => 201
+                    'init_point' => $init_point,
+                    'status'     => 201,
                 ];
-                $this->_helperData->log("Array preference ok", 'mercadopago-basic.log');
+                $this->_helperData->log('Array preference ok', 'mercadopago-basic.log');
             } else {
-                $message = "Processing error in the payment gateway. Please contact the administrator.";
+                $message = 'Processing error in the payment gateway. Please contact the administrator.';
                 if ($response['status'] == 500) {
-                    $message = "Error on process of payment data. Please contact the administrator.";
+                    $message = 'Error on process of payment data. Please contact the administrator.';
                 }
 
                 $array_assign = [
-                    "message" => __($message),
-                    "json" => json_encode($response),
-                    "status" => 400
+                    'message' => __($message),
+                    'json'    => json_encode($response),
+                    'status'  => 400,
                 ];
                 $this->_helperData->log($message, 'mercadopago-basic.log');
-            }
+            }//end if
+
             return $array_assign;
         } catch (Exception $e) {
-            $this->_helperData->log('Fatal Error: Model Basic Payment PostPago:' . $e->getMessage(), 'mercadopago-basic.log');
+            $this->_helperData->log('Fatal Error: Model Basic Payment PostPago:'.$e->getMessage(), 'mercadopago-basic.log');
             return [];
-        }
-    }
+        }//end try
+
+    }//end postPago()
+
 
     /**
-     * @param $params
-     * @param $order
-     * @param $shippingAddress
+     * @param  $params
+     * @param  $order
+     * @param  $shippingAddress
      * @return mixed
      */
     protected function _getParamShipment($params, $order, $shippingAddress)
     {
         $paramsShipment = $params->getParams();
         if (empty($paramsShipment)) {
-            $paramsShipment = $params->getData();
-            $paramsShipment['cost'] = (float)$order->getBaseShippingAmount();
+            $paramsShipment         = $params->getData();
+            $paramsShipment['cost'] = (float) $order->getBaseShippingAmount();
             $paramsShipment['mode'] = 'custom';
         }
+
         $paramsShipment['receiver_address'] = $this->getReceiverAddress($shippingAddress);
         return $paramsShipment;
-    }
+
+    }//end _getParamShipment()
+
 
     /**
      * @return string
@@ -182,25 +213,35 @@ class Payment extends AbstractMethod
     public function getActionUrl()
     {
         return $this->_urlBuilder->getUrl(self::ACTION_URL);
-    }
+
+    }//end getActionUrl()
+
 
     /**
-     * @param CartInterface|null $quote
-     * @return bool
+     * @param  CartInterface|null $quote
+     * @return boolean
      */
-    public function isAvailable(CartInterface $quote = null)
+    public function isAvailable(CartInterface $quote=null)
     {
         $isActive = $this->_scopeConfig->getValue(
             \MercadoPago\Core\Helper\ConfigData::PATH_BASIC_ACTIVE,
             \Magento\Store\Model\ScopeInterface::SCOPE_STORE
         );
 
+        if ($quote instanceof CartInterface
+            && $quote->getPayment()->getAdditionalInformation('purpose') === 'wallet_purchase'
+        ) {
+            return true;
+        }
+
         if (empty($isActive)) {
             return false;
         }
 
         return parent::isAvailable($quote);
-    }
+
+    }//end isAvailable()
+
 
     /**
      * @return string
@@ -214,5 +255,8 @@ class Payment extends AbstractMethod
 
         $successUrl = $successPage ? 'mercadopago/checkout/page' : 'checkout/onepage/success';
         return $this->_urlBuilder->getUrl($successUrl, ['_secure' => true]);
-    }
-}
+
+    }//end getOrderPlaceRedirectUrl()
+
+
+}//end class

--- a/src/MercadoPago/Core/Model/Preference/Wallet.php
+++ b/src/MercadoPago/Core/Model/Preference/Wallet.php
@@ -261,6 +261,7 @@ class Wallet
         $quoteId = $payment['metadata']['quote_id'];
 
         $quote = $this->quoteRepository->get($quoteId);
+        $quote->getPayment()->setAdditionalInformation('purpose', 'wallet_purchase');
         $quote->getPayment()->importData(['method' => 'mercadopago_basic']);
 
         $orderId = $this->quoteManagement->placeOrder($quote->getId());


### PR DESCRIPTION
Um ajuste para que seja possível usar o Wallet Button, mesmo quando o CHO Pro está desligado.

https://mercadolibre.atlassian.net/browse/PLUG-1538

Para testar, só deixar o CHO Pro desligado e ativar o Wallet Button:

![image](https://user-images.githubusercontent.com/1247740/145038600-7d3c5e39-625a-42b4-beed-b2988c2f161b.png)
![image](https://user-images.githubusercontent.com/1247740/145038671-07ea1b50-a412-4124-9831-7cb1de1965ae.png)
