### PR TITLE
[PPWP-531] Improvement: dynamically removing unavailable payment methods from admin

### DIFF
--- a/src/MercadoPago/Core/Block/Adminhtml/System/Config/Fieldset/Payment.php
+++ b/src/MercadoPago/Core/Block/Adminhtml/System/Config/Fieldset/Payment.php
@@ -22,15 +22,13 @@ use MercadoPago\Core\Helper\Cache;
 class Payment extends Fieldset
 {
 
-    const CHECKOUT_CONFIG_PREFIX = 'payment_us_mercadopago_configurations_';
-
     /**
      * checkout types
      */
-    const CHECKOUT_CUSTOM_CARD = self::CHECKOUT_CONFIG_PREFIX . 'custom_checkout';
-    const CHECKOUT_CUSTOM_PIX= self::CHECKOUT_CONFIG_PREFIX . 'custom_checkout_pix';
-    const CHECKOUT_CUSTOM_TICKET = self::CHECKOUT_CONFIG_PREFIX . 'custom_checkout_ticket';
-    const CHECKOUT_CUSTOM_BANK_TRANSFER = self::CHECKOUT_CONFIG_PREFIX . 'custom_checkout_bank_transfer';
+    const CHECKOUT_CUSTOM_CARD = 'custom_checkout';
+    const CHECKOUT_CUSTOM_PIX= 'custom_checkout_pix';
+    const CHECKOUT_CUSTOM_TICKET = 'custom_checkout_ticket';
+    const CHECKOUT_CUSTOM_BANK_TRANSFER = 'custom_checkout_bank_transfer';
 
     /**
      * @var ScopeConfigInterface
@@ -173,11 +171,12 @@ class Payment extends Fieldset
         $validCheckoutOptions = json_decode($this->cache->getFromCache($cacheKey));
         if (!$validCheckoutOptions) {
             $validCheckoutOptions = $this->getAvailableCheckoutOptions();
-
             $this->cache->saveCache($cacheKey, json_encode($validCheckoutOptions));
         }
+        
+        $paymentIdWithoutPrefix = implode('_', array_slice(explode('_', $paymentId), 4));
 
-        return !in_array($paymentId, $validCheckoutOptions);
+        return !in_array($paymentIdWithoutPrefix, $validCheckoutOptions);
     }
 
     /**

--- a/src/MercadoPago/Core/Block/Adminhtml/System/Config/Fieldset/Payment.php
+++ b/src/MercadoPago/Core/Block/Adminhtml/System/Config/Fieldset/Payment.php
@@ -226,7 +226,7 @@ class Payment extends Fieldset
             }
 
             return $availableCheckouts;
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             return [];
         }
     }

--- a/src/MercadoPago/Core/Block/Adminhtml/System/Config/Fieldset/Payment.php
+++ b/src/MercadoPago/Core/Block/Adminhtml/System/Config/Fieldset/Payment.php
@@ -26,9 +26,10 @@ class Payment extends Fieldset
     /**
      * checkout types
      */
-    const CHECKOUT_CUSTOM_CARD = 'custom_checkout';
-    const CHECKOUT_CUSTOM_TICKET = 'custom_checkout_ticket';
-    const CHECKOUT_CUSTOM_BANK_TRANSFER = 'custom_checkout_bank_transfer';
+    const CHECKOUT_CUSTOM_CARD = self::CHECKOUT_CONFIG_PREFIX . 'custom_checkout';
+    const CHECKOUT_CUSTOM_PIX= self::CHECKOUT_CONFIG_PREFIX . 'custom_checkout_pix';
+    const CHECKOUT_CUSTOM_TICKET = self::CHECKOUT_CONFIG_PREFIX . 'custom_checkout_ticket';
+    const CHECKOUT_CUSTOM_BANK_TRANSFER = self::CHECKOUT_CONFIG_PREFIX . 'custom_checkout_bank_transfer';
 
     /**
      * @var ScopeConfigInterface
@@ -106,11 +107,6 @@ class Payment extends Fieldset
             $this->coreHelper->log('Método inválido!', 'mercadopago.log');
 
             //$this->disablePayment(ConfigData::PATH_CUSTOM_PIX_ACTIVE);
-            return "";
-        }
-
-        //check pix
-        if ($this->hidePix($paymentId)) {
             return "";
         }
 
@@ -192,20 +188,23 @@ class Payment extends Fieldset
                     case 'debid_card':
                     case 'prepaid_card':
                         if (!in_array(self::CHECKOUT_CUSTOM_CARD, $availableCheckouts)) {
-                            $availableCheckouts[] = self::CHECKOUT_CONFIG_PREFIX . self::CHECKOUT_CUSTOM_CARD;
+                            $availableCheckouts[] = self::CHECKOUT_CUSTOM_CARD;
                         }
                         break;
 
                     case 'atm':
                     case 'ticket':
                         if (!in_array(self::CHECKOUT_CUSTOM_TICKET, $availableCheckouts)) {
-                            $availableCheckouts[] = self::CHECKOUT_CONFIG_PREFIX . self::CHECKOUT_CUSTOM_TICKET;
+                            $availableCheckouts[] = self::CHECKOUT_CUSTOM_TICKET;
                         }
                         break;
 
                     case 'bank_transfer':
-                        if (!in_array(self::CHECKOUT_CUSTOM_TICKET, $availableCheckouts) && $paymentMethod['id'] !== 'pix') {
-                            $availableCheckouts[] = self::CHECKOUT_CONFIG_PREFIX . self::CHECKOUT_CUSTOM_BANK_TRANSFER;
+                        if (!in_array(self::CHECKOUT_CUSTOM_PIX, $availableCheckouts) && strtolower($paymentMethod['id']) === 'pix') {
+                            $availableCheckouts[] = self::CHECKOUT_CUSTOM_PIX;
+                        }
+                        if (!in_array(self::CHECKOUT_CUSTOM_BANK_TRANSFER, $availableCheckouts) && strtolower($paymentMethod['id']) !== 'pix') {
+                            $availableCheckouts[] = self::CHECKOUT_CUSTOM_BANK_TRANSFER;
                         }
                         break;
                 }
@@ -215,29 +214,5 @@ class Payment extends Fieldset
         } catch (Exception $e) {
             return [];
         }
-    }
-
-    /**
-     * @param  $paymentId
-     * @return bool
-     */
-    protected function hidePix($paymentId)
-    {
-        if (strpos($paymentId, 'custom_checkout_pix') !== false) {
-
-            $siteId = strtoupper(
-                $this->scopeConfig->getValue(
-                    ConfigData::PATH_SITE_ID,
-                    ScopeInterface::SCOPE_STORE
-                )
-            );
-
-            if ($siteId !== "MLB") {
-                $this->disablePayment(ConfigData::PATH_CUSTOM_PIX_ACTIVE);
-                return true;
-            }
-        }
-
-        return false;
     }
 }

--- a/src/MercadoPago/Core/Block/Adminhtml/System/Config/Fieldset/Payment.php
+++ b/src/MercadoPago/Core/Block/Adminhtml/System/Config/Fieldset/Payment.php
@@ -111,7 +111,6 @@ class Payment extends Fieldset
 
         //check available payment methods
         if ($this->hideInvalidCheckoutOptions($paymentId)) {
-            $this->coreHelper->log('disabling ' . $paymentId);
             $this->disablePayment($paymentId);
             return "";
         }
@@ -137,18 +136,13 @@ class Payment extends Fieldset
     {
         $paymentActivePath = $this->getPaymentPath($paymentId);
 
-        $this->coreHelper->log('$paymentActivePath ' . $paymentActivePath);
-
         $statusPaymentMethod = $this->scopeConfig->isSetFlag(
             $paymentActivePath,
             ScopeInterface::SCOPE_STORE
         );
 
-        $this->coreHelper->log('$statusPaymentMethod ' . $statusPaymentMethod);
-
         //check is active for disable
         if ($paymentActivePath && $statusPaymentMethod) {
-            $this->coreHelper->log('true');
             $value = 0;
 
             if ($this->switcher->getWebsiteId() == 0) {
@@ -178,7 +172,8 @@ class Payment extends Fieldset
         $cacheKey = Cache::VALID_PAYMENT_METHODS;
         $validCheckoutOptions = json_decode($this->cache->getFromCache($cacheKey));
         if (!$validCheckoutOptions) {
-            $validCheckoutOptions = $this->getAvailableCheckoutsOptions();
+            $validCheckoutOptions = $this->getAvailableCheckoutOptions();
+
             $this->cache->saveCache($cacheKey, json_encode($validCheckoutOptions));
         }
 
@@ -191,7 +186,7 @@ class Payment extends Fieldset
      * @param string $accessToken
      * @return array
      */
-    public function getAvailableCheckoutsOptions()
+    public function getAvailableCheckoutOptions()
     {
         try {
             $availableCheckouts = array();
@@ -227,6 +222,7 @@ class Payment extends Fieldset
 
             return $availableCheckouts;
         } catch (\Exception $e) {
+            $this->coreHelper->log('Payment Fieldset getAvailableCheckoutOptions error: ' . $e->getMessage());
             return [];
         }
     }

--- a/src/MercadoPago/Core/Helper/Cache.php
+++ b/src/MercadoPago/Core/Helper/Cache.php
@@ -13,6 +13,7 @@ class Cache
 {
     const PREFIX_KEY = 'MP_';
     const IS_VALID_AT = 'IS_VALID_ACCESS_TOKEN';
+    const VALID_PAYMENT_METHODS = 'VALID_PAYMENT_METHODS';
 
     /**
      * @var CacheInterface

--- a/src/MercadoPago/Core/Helper/Cache.php
+++ b/src/MercadoPago/Core/Helper/Cache.php
@@ -8,6 +8,8 @@ use Magento\Framework\View\Element\Context;
 /**
  * Class Cache
  * @package MercadoPago\Core\Helper
+ * 
+ * @codeCoverageIgnore
  */
 class Cache
 {

--- a/src/MercadoPago/Core/Observer/ConfigObserver.php
+++ b/src/MercadoPago/Core/Observer/ConfigObserver.php
@@ -18,6 +18,8 @@ use MercadoPago\Core\Helper\Data;
  * Class ConfigObserver
  *
  * @package MercadoPago\Core\Observer
+ * 
+ * @codeCoverageIgnore
  */
 class ConfigObserver implements ObserverInterface
 {

--- a/src/MercadoPago/Core/Observer/ConfigObserver.php
+++ b/src/MercadoPago/Core/Observer/ConfigObserver.php
@@ -48,16 +48,6 @@ class ConfigObserver implements ObserverInterface
     ];
 
     /**
-     * @var array
-     */
-    private $available_transparent_credit_cart = ['MLA', 'MLB', 'MLM', 'MLV', 'MLC', 'MCO', 'MPE', 'MLU'];
-
-    /**
-     * @var array
-     */
-    private $available_transparent_ticket = ['MLA', 'MLB', 'MLM', 'MLV', 'MLC', 'MCO', 'MPE', 'MLU'];
-
-    /**
      *
      */
     const LOG_NAME = 'mercadopago';
@@ -138,33 +128,8 @@ class ConfigObserver implements ObserverInterface
     {
         $this->validateAccessToken();
         $this->setUserInfo();
-        $this->availableCheckout();
         $this->checkBanner('mercadopago_custom');
         $this->checkBanner('mercadopago_customticket');
-    }
-
-    /**
-     * Disables custom checkout if selected country is not available
-     */
-    public function availableCheckout()
-    {
-        $country = $this->country;
-
-        if ($country == "") {
-            $country = $this->_scopeConfig->getValue(
-                ConfigData::PATH_SITE_ID,
-                ScopeInterface::SCOPE_WEBSITE,
-                $this->_scopeCode
-            );
-        }
-
-        if (!in_array(strtoupper($country), $this->available_transparent_credit_cart)) {
-            $this->_saveWebsiteConfig(ConfigData::PATH_CUSTOM_ACTIVE, 0);
-        }
-
-        if (!in_array(strtoupper($country), $this->available_transparent_ticket)) {
-            $this->_saveWebsiteConfig(ConfigData::PATH_CUSTOM_TICKET_ACTIVE, 0);
-        }
     }
 
     /**

--- a/src/MercadoPago/Core/Observer/ConfigObserver.php
+++ b/src/MercadoPago/Core/Observer/ConfigObserver.php
@@ -50,12 +50,12 @@ class ConfigObserver implements ObserverInterface
     /**
      * @var array
      */
-    private $available_transparent_credit_cart = ['MLA', 'MLB', 'MLM', 'MLV', 'MLC', 'MCO', 'MPE'];
+    private $available_transparent_credit_cart = ['MLA', 'MLB', 'MLM', 'MLV', 'MLC', 'MCO', 'MPE', 'MLU'];
 
     /**
      * @var array
      */
-    private $available_transparent_ticket = ['MLA', 'MLB', 'MLM', 'MLV', 'MLC', 'MCO', 'MPE'];
+    private $available_transparent_ticket = ['MLA', 'MLB', 'MLM', 'MLV', 'MLC', 'MCO', 'MPE', 'MLU'];
 
     /**
      *

--- a/src/MercadoPago/Core/etc/adminhtml/system/custom_checkout.xml
+++ b/src/MercadoPago/Core/etc/adminhtml/system/custom_checkout.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <include xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_include.xsd">
     <group id="custom_checkout" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
+        <frontend_model>MercadoPago\Core\Block\Adminhtml\System\Config\Fieldset\Payment</frontend_model>
         <label>Custom Checkout - Credit and Debit Card</label>
 
         <field id="active" translate="label comment" type="select" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="0">

--- a/src/MercadoPago/Core/etc/adminhtml/system/custom_checkout_ticket.xml
+++ b/src/MercadoPago/Core/etc/adminhtml/system/custom_checkout_ticket.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <include xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_include.xsd">
     <group id="custom_checkout_ticket" translate="label" type="text" sortOrder="25" showInDefault="1" showInWebsite="1" showInStore="1">
+        <frontend_model>MercadoPago\Core\Block\Adminhtml\System\Config\Fieldset\Payment</frontend_model>
         <label>Custom Checkout - Offline Payments Methods (Ticket)</label>
 
         <field id="active" translate="label" type="select" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="0">

--- a/src/MercadoPago/Test/Unit/Block/Fieldset/PaymentTest.php
+++ b/src/MercadoPago/Test/Unit/Block/Fieldset/PaymentTest.php
@@ -120,4 +120,36 @@ class PaymentTest extends TestCase
 
         $this->assertEquals("", $this->payment->render($this->abstractElementMock));
     }
+
+    public function testGetAvailableCheckoutsOptions_success_returnOptions(): void {
+        $this->coreHelperMock
+        ->expects($this->any())
+        ->method('getAccessToken')
+        ->willReturn('access_token');
+
+        $this->coreHelperMock
+        ->expects($this->any())
+        ->method('getMercadoPagoPaymentMethods')
+        ->willReturn(PaymentResponseMock::RESPONSE_PAYMENT_METHODS_SUCCESS);
+
+        $checkoutOptions = $this->payment->getAvailableCheckoutsOptions();
+
+        $this->assertEquals($checkoutOptions, array(Payment::CHECKOUT_CUSTOM_CARD, Payment::CHECKOUT_CUSTOM_TICKET, Payment::CHECKOUT_CUSTOM_BANK_TRANSFER));
+    }
+
+    public function testGetAvailableCheckoutsOptions_success_returnEmpty(): void {
+        $this->coreHelperMock
+        ->expects($this->any())
+        ->method('getAccessToken')
+        ->willReturn('access_token');
+
+        $this->coreHelperMock
+        ->expects($this->any())
+        ->method('getMercadoPagoPaymentMethods')
+        ->willReturn(PaymentResponseMock::RESPONSE_PAYMENT_METHODS_FAILURE);
+
+        $checkoutOptions = $this->payment->getAvailableCheckoutsOptions();
+
+        $this->assertEquals($checkoutOptions, array());
+    }
 }

--- a/src/MercadoPago/Test/Unit/Block/Fieldset/PaymentTest.php
+++ b/src/MercadoPago/Test/Unit/Block/Fieldset/PaymentTest.php
@@ -132,12 +132,28 @@ class PaymentTest extends TestCase
         ->method('getMercadoPagoPaymentMethods')
         ->willReturn(PaymentResponseMock::RESPONSE_PAYMENT_METHODS_SUCCESS);
 
-        $checkoutOptions = $this->payment->getAvailableCheckoutsOptions();
+        $checkoutOptions = $this->payment->getAvailableCheckoutOptions();
 
         $this->assertEquals($checkoutOptions, array(Payment::CHECKOUT_CUSTOM_CARD, Payment::CHECKOUT_CUSTOM_TICKET, Payment::CHECKOUT_CUSTOM_BANK_TRANSFER));
     }
 
-    public function testGetAvailableCheckoutsOptions_success_returnEmpty(): void {
+    public function testGetAvailableCheckoutsOptions_success_returnOptionsWithPix(): void {
+        $this->coreHelperMock
+        ->expects($this->any())
+        ->method('getAccessToken')
+        ->willReturn('access_token');
+
+        $this->coreHelperMock
+        ->expects($this->any())
+        ->method('getMercadoPagoPaymentMethods')
+        ->willReturn(PaymentResponseMock::RESPONSE_PAYMENT_METHODS_SUCCESS_MLB);
+
+        $checkoutOptions = $this->payment->getAvailableCheckoutOptions();
+
+        $this->assertEquals($checkoutOptions, array(Payment::CHECKOUT_CUSTOM_CARD, Payment::CHECKOUT_CUSTOM_PIX, Payment::CHECKOUT_CUSTOM_TICKET));
+    }
+
+    public function testGetAvailableCheckoutsOptions_failure_returnEmpty(): void {
         $this->coreHelperMock
         ->expects($this->any())
         ->method('getAccessToken')
@@ -148,7 +164,23 @@ class PaymentTest extends TestCase
         ->method('getMercadoPagoPaymentMethods')
         ->willReturn(PaymentResponseMock::RESPONSE_PAYMENT_METHODS_FAILURE);
 
-        $checkoutOptions = $this->payment->getAvailableCheckoutsOptions();
+        $checkoutOptions = $this->payment->getAvailableCheckoutOptions();
+
+        $this->assertEquals($checkoutOptions, array());
+    }
+
+    public function testGetAvailableCheckoutsOptions_exception_returnEmpty(): void {
+        $this->coreHelperMock
+        ->expects($this->any())
+        ->method('getAccessToken')
+        ->willReturn('access_token');
+
+        $this->coreHelperMock
+        ->expects($this->any())
+        ->method('getMercadoPagoPaymentMethods')
+        ->will($this->throwException(new \Exception()));
+
+        $checkoutOptions = $this->payment->getAvailableCheckoutOptions();
 
         $this->assertEquals($checkoutOptions, array());
     }


### PR DESCRIPTION
Removing payment options for unavailable payment methods on the admin page.
For example, if a credential doesn't accept bank_transfer payments, then the bank_transfer becomes hidden on the admin's page configuration page.